### PR TITLE
Define files that should not be exported to releases

### DIFF
--- a/.gitattributes.yml
+++ b/.gitattributes.yml
@@ -1,5 +1,6 @@
 /benchmark export-ignore
 /bin export-ignore
+/tests export-ignore
 /vendor export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore

--- a/.gitattributes.yml
+++ b/.gitattributes.yml
@@ -1,0 +1,9 @@
+/benchmark export-ignore
+/bin export-ignore
+/vendor export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/.php_cs export-ignore
+/.scrutinizer.yml export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
This way we remove the not necessary files from the final release package(.zip) and reduce the download size when the library is download from dist with composer.